### PR TITLE
Adding 'First' and 'Last' Epoch Timestamps on upload complete webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ Available events are:
 
 Each event type has a specific payload format with the relevant event information.
 
+#### Webhook Payload Parameters
+
+| Name        | Type | Accepted Values | Statuses where displayed | Description  |
+| ------------- |:----------:|  -----: | -----: |  -----: |
+| status      | String | "started", "completed", "error" | "started", "completed", "error" | Status of upload processing
+| uploadId      | Integer    |   |  "started", "completed", "error" | Unique identifier for subject upload |
+| studyId | Integer  |    | "started", "completed", "error" |  Unique identifier for study |
+| subjectId | Integer     |   | "started", "completed", "error" |Unique identifier for subject |
+| message | String  |  | "error"| Contents of error message if error occurs during upload processing. Parameter will only exist if the status equals 'error'. |
+| firstEpochUTC | DateTime  |    | "completed"  | First Epoch Timestamp (in UTC) of added data from upload  |
+| firstEpochSubjectTZ | DateTime      |   | "completed"  | First Epoch Timestamp (in subject's timezone) of added data from upload |
+| lastEpochUTC | DateTime     |    | "completed" | Last Epoch Timestamp (in UTC) of added data from upload |
+| lastEpochSubjectTZ | DateTime      |   | "completed" | Last Epoch Timestamp (in subject's timezone) of added data from upload  |
+
+
+
 ### Delivery headers
 
 HTTP requests made to your webhook's configured URL endpoint will contain several special headers:
@@ -33,7 +49,7 @@ HTTP requests made to your webhook's configured URL endpoint will contain severa
 4. `X-Actigraph-Webhook-Id` Unique ID of the configured webhook.
 4. `User-Agent: ActiGraph-Hookshot/`
 
-### Example delivery
+### Example delivery with Upload 'started' status
 
 ```json
 POST /payload HTTP/1.1
@@ -49,10 +65,63 @@ X-Actigraph-Event: upload
 X-Actigraph-Signature: sha1=E2316FEDF726CBB2FD31EA25FF55E966A4543EEC290944DA578ADB42CD0DE9D60A1435D120525074535BEABD083BFE7C0CB5451BBEFB5B55BC6C60A10449E34E
 
 {
-	"status" : "Started",
-	"uploadId" : "123456",
-	"subjectId" : "987654",
-	"studyId" : "456789"
+	"status" : "started",
+	"uploadId" : "85045",
+	"subjectId" : "44732",
+	"studyId" : "189"
+}
+
+```
+
+### Example delivery with Upload 'completed' status
+
+```json
+POST /payload HTTP/1.1
+
+Host: localhost:4567
+Content-Length: 98
+User-Agent: ActiGraph-Hookshot/1.0
+Content-Type: application/json
+X-Request-Id: 3a09f5c9-824e-4de5-8aca-dcdd6db4b9f8
+X-Actigraph-Webhook-Id: 15
+X-Actigraph-Delivery: bc0e8916-ca49-41d8-9c97-eb6b286dcc78
+X-Actigraph-Event: upload
+X-Actigraph-Signature: sha1=E2316FEDF726CBB2FD31EA25FF55E966A4543EEC290944DA578ADB42CD0DE9D60A1435D120525074535BEABD083BFE7C0CB5451BBEFB5B55BC6C60A10449E34E
+
+{
+	"status" : "completed",
+	"firstEpochUTC" : "6/14/2016 8:46:00 PM",
+	"firstEpochSubjectTZ" : "6/14/2016 3:46:00 PM",
+	"lastEpochUTC" : "6/14/2016 8:47:00 PM",
+	"lastEpochSubjectTZ" : "6/14/2016 3:47:00 PM",
+	"uploadId" : "85045",
+	"subjectId" : "44732",
+	"studyId" : "189"
+}
+
+```
+
+### Example delivery with Upload 'error' status
+
+```json
+POST /payload HTTP/1.1
+
+Host: localhost:4567
+Content-Length: 98
+User-Agent: ActiGraph-Hookshot/1.0
+Content-Type: application/json
+X-Request-Id: 3a09f5c9-824e-4de5-8aca-dcdd6db4b9f8
+X-Actigraph-Webhook-Id: 15
+X-Actigraph-Delivery: bc0e8916-ca49-41d8-9c97-eb6b286dcc78
+X-Actigraph-Event: upload
+X-Actigraph-Signature: sha1=E2316FEDF726CBB2FD31EA25FF55E966A4543EEC290944DA578ADB42CD0DE9D60A1435D120525074535BEABD083BFE7C0CB5451BBEFB5B55BC6C60A10449E34E
+
+{
+	"status" : "error",
+	"message" : "A problem occured during upload processing",
+	"uploadId" : "85045",
+	"subjectId" : "44732",
+	"studyId" : "189"
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Each event type has a specific payload format with the relevant event informatio
 | uploadId      | Integer    |   |  "started", "completed", "error" | Unique identifier for subject upload |
 | studyId | Integer  |    | "started", "completed", "error" |  Unique identifier for study |
 | subjectId | Integer     |   | "started", "completed", "error" |Unique identifier for subject |
-| message | String  |  | "error"| Contents of error message if error occurs during upload processing. Parameter will only exist if the status equals 'error'. |
+| message | String  |  | "error"| Contents of error message if error occurs during upload processing. |
 | firstEpochUTC | DateTime  |    | "completed"  | First Epoch Timestamp (in UTC) of added data from upload  |
 | firstEpochSubjectTZ | DateTime      |   | "completed"  | First Epoch Timestamp (in subject's timezone) of added data from upload |
 | lastEpochUTC | DateTime     |    | "completed" | Last Epoch Timestamp (in UTC) of added data from upload |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ HTTP requests made to your webhook's configured URL endpoint will contain severa
 4. `X-Actigraph-Webhook-Id` Unique ID of the configured webhook.
 4. `User-Agent: ActiGraph-Hookshot/`
 
-### Example delivery with Upload 'started' status
+### Example delivery with upload 'started' status
 
 ```json
 POST /payload HTTP/1.1
@@ -73,7 +73,7 @@ X-Actigraph-Signature: sha1=E2316FEDF726CBB2FD31EA25FF55E966A4543EEC290944DA578A
 
 ```
 
-### Example delivery with Upload 'completed' status
+### Example delivery with upload 'completed' status
 
 ```json
 POST /payload HTTP/1.1
@@ -101,7 +101,7 @@ X-Actigraph-Signature: sha1=E2316FEDF726CBB2FD31EA25FF55E966A4543EEC290944DA578A
 
 ```
 
-### Example delivery with Upload 'error' status
+### Example delivery with upload 'error' status
 
 ```json
 POST /payload HTTP/1.1

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Each event type has a specific payload format with the relevant event informatio
 | studyId | Integer  |    | "started", "completed", "error" |  Unique identifier for study |
 | subjectId | Integer     |   | "started", "completed", "error" |Unique identifier for subject |
 | message | String  |  | "error"| Contents of error message if error occurs during upload processing. |
-| firstEpochUTC | DateTime  |    | "completed"  | First Epoch Timestamp (in UTC) of added data from upload  |
-| firstEpochSubjectTZ | DateTime      |   | "completed"  | First Epoch Timestamp (in subject's timezone) of added data from upload |
-| lastEpochUTC | DateTime     |    | "completed" | Last Epoch Timestamp (in UTC) of added data from upload |
-| lastEpochSubjectTZ | DateTime      |   | "completed" | Last Epoch Timestamp (in subject's timezone) of added data from upload  |
+| firstEpochUTC | DateTime (ISO 8601)  |    | "completed"  | First Epoch Timestamp (in UTC) of added data from upload  |
+| firstEpochSubjectTZ | DateTime (ISO 8601)  |   | "completed"  | First Epoch Timestamp (in subject's timezone) of added data from upload |
+| lastEpochUTC | DateTime (ISO 8601)    |    | "completed" | Last Epoch Timestamp (in UTC) of added data from upload |
+| lastEpochSubjectTZ | DateTime (ISO 8601)     |   | "completed" | Last Epoch Timestamp (in subject's timezone) of added data from upload  |
 
 
 
@@ -90,10 +90,10 @@ X-Actigraph-Signature: sha1=E2316FEDF726CBB2FD31EA25FF55E966A4543EEC290944DA578A
 
 {
 	"status" : "completed",
-	"firstEpochUTC" : "6/14/2016 8:46:00 PM",
-	"firstEpochSubjectTZ" : "6/14/2016 3:46:00 PM",
-	"lastEpochUTC" : "6/14/2016 8:47:00 PM",
-	"lastEpochSubjectTZ" : "6/14/2016 3:47:00 PM",
+	"firstEpochUTC" : "2016-06-14T20:46:00.0000000",
+	"firstEpochSubjectTZ" : "2016-06-14T15:46:00.0000000",
+	"lastEpochUTC" : "2016-06-14T20:47:00.0000000",
+	"lastEpochSubjectTZ" : "2016-06-14T15:47:00.0000000",
 	"uploadId" : "85045",
 	"subjectId" : "44732",
 	"studyId" : "189"

--- a/event_types.md
+++ b/event_types.md
@@ -18,10 +18,10 @@ Triggered when a upload occurs from any ActiGraph system (ActiSync or CentrePoin
 | studyId | Integer  |    | "started", "completed", "error" |  Unique identifier for study |
 | subjectId | Integer     |   | "started", "completed", "error" |Unique identifier for subject |
 | message | String  |  | "error"| Contents of error message if error occurs during upload processing. |
-| firstEpochUTC | DateTime  |    | "completed"  | First Epoch Timestamp (in UTC) of added data from upload  |
-| firstEpochSubjectTZ | DateTime      |   | "completed"  | First Epoch Timestamp (in subject's timezone) of added data from upload |
-| lastEpochUTC | DateTime     |    | "completed" | Last Epoch Timestamp (in UTC) of added data from upload |
-| lastEpochSubjectTZ | DateTime      |   | "completed" | Last Epoch Timestamp (in subject's timezone) of added data from upload  |
+| firstEpochUTC | DateTime (ISO 8601)  |    | "completed"  | First Epoch Timestamp (in UTC) of added data from upload  |
+| firstEpochSubjectTZ | DateTime (ISO 8601)      |   | "completed"  | First Epoch Timestamp (in subject's timezone) of added data from upload |
+| lastEpochUTC | DateTime (ISO 8601)    |    | "completed" | Last Epoch Timestamp (in UTC) of added data from upload |
+| lastEpochSubjectTZ | DateTime (ISO 8601)     |   | "completed" | Last Epoch Timestamp (in subject's timezone) of added data from upload  |
 
 
 
@@ -67,10 +67,10 @@ X-Actigraph-Signature: sha1=E2316FEDF726CBB2FD31EA25FF55E966A4543EEC290944DA578A
 
 {
 	"status" : "completed",
-	"firstEpochUTC" : "6/14/2016 8:46:00 PM",
-	"firstEpochSubjectTZ" : "6/14/2016 3:46:00 PM",
-	"lastEpochUTC" : "6/14/2016 8:47:00 PM",
-	"lastEpochSubjectTZ" : "6/14/2016 3:47:00 PM",
+	"firstEpochUTC":"2016-06-14T20:46:00.0000000",
+	"firstEpochSubjectTZ":"2016-06-14T15:46:00.0000000",
+	"lastEpochUTC":"2016-06-14T20:47:00.0000000",
+	"lastEpochSubjectTZ":"2016-06-14T15:47:00.0000000",
 	"uploadId" : "85045",
 	"subjectId" : "44732",
 	"studyId" : "189"

--- a/event_types.md
+++ b/event_types.md
@@ -17,7 +17,7 @@ Triggered when a upload occurs from any ActiGraph system (ActiSync or CentrePoin
 | uploadId      | Integer    |   |  "started", "completed", "error" | Unique identifier for subject upload |
 | studyId | Integer  |    | "started", "completed", "error" |  Unique identifier for study |
 | subjectId | Integer     |   | "started", "completed", "error" |Unique identifier for subject |
-| message | String  |  | "error"| Contents of error message if error occurs during upload processing. Parameter will only exist if the status equals 'error'. |
+| message | String  |  | "error"| Contents of error message if error occurs during upload processing. |
 | firstEpochUTC | DateTime  |    | "completed"  | First Epoch Timestamp (in UTC) of added data from upload  |
 | firstEpochSubjectTZ | DateTime      |   | "completed"  | First Epoch Timestamp (in subject's timezone) of added data from upload |
 | lastEpochUTC | DateTime     |    | "completed" | Last Epoch Timestamp (in UTC) of added data from upload |

--- a/event_types.md
+++ b/event_types.md
@@ -25,8 +25,8 @@ Triggered when a upload occurs from any ActiGraph system (ActiSync or CentrePoin
 
 
 
-#### Webhook payload example on 'started' status
-The following are the parameters within the webhook request on Upload Started
+#### Webhook payload example with 'started' status
+The following are the parameters within the webhook request when upload processing is started
 
 ```json
 POST /payload HTTP/1.1
@@ -50,7 +50,8 @@ X-Actigraph-Signature: sha1=E2316FEDF726CBB2FD31EA25FF55E966A4543EEC290944DA578A
 
 ```
 
-#### Webhook payload example on 'completed' status
+#### Webhook payload example with 'completed' status
+The following are the parameters within the webhook request when upload processing is completed
 ```json
 POST /payload HTTP/1.1
 
@@ -77,7 +78,30 @@ X-Actigraph-Signature: sha1=E2316FEDF726CBB2FD31EA25FF55E966A4543EEC290944DA578A
 
 ```
 
+#### Webhook payload example with 'error' status
+The following are the parameters within the webhook request when error occurs during upload processing
+```json
+POST /payload HTTP/1.1
 
+Host: localhost:4567
+Content-Length: 98
+User-Agent: ActiGraph-Hookshot/1.0
+Content-Type: application/json
+X-Request-Id: 3a09f5c9-824e-4de5-8aca-dcdd6db4b9f8
+X-Actigraph-Webhook-Id: 15
+X-Actigraph-Delivery: bc0e8916-ca49-41d8-9c97-eb6b286dcc78
+X-Actigraph-Event: upload
+X-Actigraph-Signature: sha1=E2316FEDF726CBB2FD31EA25FF55E966A4543EEC290944DA578ADB42CD0DE9D60A1435D120525074535BEABD083BFE7C0CB5451BBEFB5B55BC6C60A10449E34E
+
+{
+	"status" : "error",
+	"message" : "A problem occured during upload processing",
+	"uploadId" : "85045",
+	"subjectId" : "44732",
+	"studyId" : "189"
+}
+
+```
 
 ## More information
 

--- a/event_types.md
+++ b/event_types.md
@@ -11,7 +11,7 @@ Triggered when a upload occurs from any ActiGraph system (ActiSync or CentrePoin
 
 #### Webhook Payload Parameters
 
-| Name        | Type | Accepted Values | Statuses Where Displayed | Description  |
+| Name        | Type | Accepted Values | Statuses where displayed | Description  |
 | ------------- |:----------:|  -----: | -----: |  -----: |
 | status      | String | "started", "completed", "error" | "started", "completed", "error" | Status of upload processing
 | uploadId      | Integer    |   |  "started", "completed", "error" | Unique identifier for subject upload |

--- a/event_types.md
+++ b/event_types.md
@@ -8,7 +8,49 @@ Triggered when a upload occurs from any ActiGraph system (ActiSync or CentrePoin
 #### Webhook event name
 `upload`
 
-#### Webhook payload example
+
+#### Webhook Payload Parameters
+
+| Name        | Type | Accepted Values | Statuses Where Displayed | Description  |
+| ------------- |:----------:|  -----: | -----: |  -----: |
+| status      | String | "started", "completed", "error" | "started", "completed", "error" | Status of upload processing
+| uploadId      | Integer    |   |  "started", "completed", "error" | Unique identifier for subject upload |
+| studyId | Integer  |    | "started", "completed", "error" |  Unique identifier for study |
+| subjectId | Integer     |   | "started", "completed", "error" |Unique identifier for subject |
+| message | String  |  | "error"| Contents of error message if error occurs during upload processing. Parameter will only exist if the status equals 'error'. |
+| firstEpochUTC | DateTime  |    | "completed"  | First Epoch Timestamp (in UTC) of added data from upload  |
+| firstEpochSubjectTZ | DateTime      |   | "completed"  | First Epoch Timestamp (in subject's timezone) of added data from upload |
+| lastEpochUTC | DateTime     |    | "completed" | Last Epoch Timestamp (in UTC) of added data from upload |
+| lastEpochSubjectTZ | DateTime      |   | "completed" | Last Epoch Timestamp (in subject's timezone) of added data from upload  |
+
+
+
+#### Webhook payload example on 'started' status
+The following are the parameters within the webhook request on Upload Started
+
+```json
+POST /payload HTTP/1.1
+
+Host: localhost:4567
+Content-Length: 98
+User-Agent: ActiGraph-Hookshot/1.0
+Content-Type: application/json
+X-Request-Id: 3a09f5c9-824e-4de5-8aca-dcdd6db4b9f8
+X-Actigraph-Webhook-Id: 15
+X-Actigraph-Delivery: bc0e8916-ca49-41d8-9c97-eb6b286dcc78
+X-Actigraph-Event: upload
+X-Actigraph-Signature: sha1=E2316FEDF726CBB2FD31EA25FF55E966A4543EEC290944DA578ADB42CD0DE9D60A1435D120525074535BEABD083BFE7C0CB5451BBEFB5B55BC6C60A10449E34E
+{
+	"status" : "started",
+	"uploadId" : "85045",
+	"subjectId" : "44732",
+	"studyId" : "189"
+}
+
+
+```
+
+#### Webhook payload example on 'completed' status
 ```json
 POST /payload HTTP/1.1
 
@@ -23,14 +65,18 @@ X-Actigraph-Event: upload
 X-Actigraph-Signature: sha1=E2316FEDF726CBB2FD31EA25FF55E966A4543EEC290944DA578ADB42CD0DE9D60A1435D120525074535BEABD083BFE7C0CB5451BBEFB5B55BC6C60A10449E34E
 
 {
-	"status" : "Started or Completed or Error",
-	"message" : "Simple message pertaining to the upload. This will only appear if the upload fails in anyway.",
-	"uploadId" : "123456",
-	"subjectId" : "987654",
-	"studyId" : "456789"
+	"status" : "completed",
+	"firstEpochUTC" : "6/14/2016 8:46:00 PM",
+	"firstEpochSubjectTZ" : "6/14/2016 3:46:00 PM",
+	"lastEpochUTC" : "6/14/2016 8:47:00 PM",
+	"lastEpochSubjectTZ" : "6/14/2016 3:47:00 PM",
+	"uploadId" : "85045",
+	"subjectId" : "44732",
+	"studyId" : "189"
 }
 
 ```
+
 
 
 ## More information


### PR DESCRIPTION
I would like to update the documentation to accommodate for a new change where we are adding the 'First' and 'Last' epoch time stamps on the upload completed web hook.
